### PR TITLE
Add reflect padding mode for VAE loading

### DIFF
--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -47,6 +47,7 @@ def load_target_model(args, accelerator, model_version: str, weight_dtype):
                 accelerator.device if args.lowram else "cpu",
                 model_dtype,
                 args.disable_mmap_load_safetensors,
+                args.vae_reflection
             )
 
             # work on low-ram device

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -133,7 +133,6 @@ def _load_target_model(
 
     if vae_reflection:        
         vae = vae_with_reflection(vae)        
-        logger.info("enabled reflect padding mode in VAE")
 
     return load_stable_diffusion_format, text_encoder1, text_encoder2, vae, unet, logit_scale, ckpt_info
 
@@ -385,9 +384,21 @@ def sample_images(*args, **kwargs):
     return train_util.sample_images_common(SdxlStableDiffusionLongPromptWeightingPipeline, *args, **kwargs)
 
 def vae_with_reflection(vae):    
-    for module in vae.modules():        
-        if isinstance(module, torch.nn.Conv2d):            
-            pad_h, pad_w = module.padding if isinstance(module.padding, tuple) else (module.padding, module.padding)            
-            if pad_h > 0 or pad_w > 0:                
-                module.padding_mode = "reflect"    
-        return vae
+    """Switch padded convolutions in a VAE to reflection padding."""
+    updated = 0
+
+    for module in vae.modules():
+        if isinstance(module, torch.nn.Conv2d):
+            if isinstance(module.padding, tuple):
+                pad_h, pad_w = module.padding
+            else:
+                pad_h = pad_w = module.padding
+            if pad_h > 0 or pad_w > 0:
+                module.padding_mode = "reflect"
+                updated += 1
+
+    if updated > 0:
+        logger.info(f"enabled reflection padding for {updated} VAE conv layers")
+    else:
+        logger.info("VAE reflection padding requested but no padded convolutions were found")
+    return vae

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -63,7 +63,7 @@ def load_target_model(args, accelerator, model_version: str, weight_dtype):
 
 
 def _load_target_model(
-    name_or_path: str, vae_path: Optional[str], model_version: str, weight_dtype, device="cpu", model_dtype=None, disable_mmap=False
+    name_or_path: str, vae_path: Optional[str], model_version: str, weight_dtype, device="cpu", model_dtype=None, disable_mmap=False, vae_reflection=False
 ):
     # model_dtype only work with full fp16/bf16
     name_or_path = os.readlink(name_or_path) if os.path.islink(name_or_path) else name_or_path
@@ -129,6 +129,10 @@ def _load_target_model(
     if vae_path is not None:
         vae = model_util.load_vae(vae_path, weight_dtype)
         logger.info("additional VAE loaded")
+
+    if vae_reflection:        
+        vae = vae_with_reflection(vae)        
+        logger.info("enabled reflect padding mode in VAE")
 
     return load_stable_diffusion_format, text_encoder1, text_encoder2, vae, unet, logit_scale, ckpt_info
 
@@ -378,3 +382,11 @@ def sample_images(*args, **kwargs):
     from library.sdxl_lpw_stable_diffusion import SdxlStableDiffusionLongPromptWeightingPipeline
 
     return train_util.sample_images_common(SdxlStableDiffusionLongPromptWeightingPipeline, *args, **kwargs)
+
+def vae_with_reflection(vae):    
+    for module in vae.modules():        
+        if isinstance(module, torch.nn.Conv2d):            
+            pad_h, pad_w = module.padding if isinstance(module.padding, tuple) else (module.padding, module.padding)            
+            if pad_h > 0 or pad_w > 0:                
+                module.padding_mode = "reflect"    
+        return vae

--- a/train_network.py
+++ b/train_network.py
@@ -3182,6 +3182,11 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="do not use fp16/bf16 VAE in mixed precision (use float VAE) / mixed precisionでも fp16/bf16 VAEを使わずfloat VAEを使う",
     )
+    parser.add_argument(        
+        "--vae_reflection",        
+        action="store_true",        
+        help="Enables reflect padding mode in the conv layers of the VAE"    
+    )
     parser.add_argument(
         "--validation_seed",
         type=int,


### PR DESCRIPTION
This PR adds reflect padding mode for VAE loading, the code is adapted from https://github.com/Jelosus2/sd-scripts/commit/acc3c77e3bc3395729bc9b16e591ea72ef06d3ae  
It's for use with VAEs from https://huggingface.co/Anzhc/MS-LC-EQ-D-VR_VAE  
Example models that use the B7 vae from that repo: https://huggingface.co/Bluvoll/NoobAI_v-pred_EQ-VAE_v0.1 and https://huggingface.co/Bluvoll/Experimental_EQ-VAE_NoobAI_tests (some require [rectified flow](https://github.com/kohya-ss/sd-scripts/compare/main...bluvoll:sd-scripts:main) implementation)

I did do some basic lora trains with the eqvae vpred 0.1 model and it seems to work without 

Edit: in the [linked fork](https://github.com/bluvoll/sd-scripts/commit/03f093de33e46107eb4e64149ba9d6bc0218edd2) of sd scripts that adds RF there is also a VAE reflect padding implementation but in different files which might be more desirable? I unfortunately don't know sd-scripts code enough to determine that, but I adapted the code from the function since it seems overall like an improvement and has better log messages