### PR TITLE
make EDM2 compatible with DDP and deepspeed in FFT, and DDP + LoRA

### DIFF
--- a/library/edm2_loss_utils.py
+++ b/library/edm2_loss_utils.py
@@ -51,7 +51,7 @@ def prepare_edm2_loss_weighting(args, noise_scheduler, accelerator):
                     else:
                         return 1 / math.sqrt(max(current_step / max(constant_steps + warmup_steps, 1), 1)**decay_scaling)
                 return torch.optim.lr_scheduler.LambdaLR(optimizer=wrap_optimizer, lr_lambda=lr_lambda)
-            
+
             edm2_lr_scheduler = InverseSqrt(
                 edm2_optimizer,
                 warmup_steps=args.max_train_steps * float(args.edm2_loss_weighting_lr_scheduler_warmup_percent) if args.edm2_loss_weighting_lr_scheduler_warmup_percent is not None else 0.05,
@@ -61,9 +61,19 @@ def prepare_edm2_loss_weighting(args, noise_scheduler, accelerator):
         else:
             edm2_lr_scheduler = train_util.get_dummy_scheduler(edm2_optimizer)
 
-        edm2_lr_scheduler = accelerator.prepare(edm2_lr_scheduler)
-            
-        edm2_model, edm2_optimizer = accelerator.prepare(edm2_model, edm2_optimizer)
+        # Handle DeepSpeed differently: don't use accelerator.prepare() at all
+        # When DeepSpeed is active, prepare() converts models to bf16 and wraps them
+        # in ways that break gradient flow for separate models like EDM2
+        is_deepspeed = getattr(args, 'deepspeed', False)
+        if is_deepspeed:
+            logger.info("DeepSpeed detected: keeping EDM2 as standalone PyTorch model (float32)")
+            # Just move to device, keep as float32 for stable gradient computation
+            edm2_model = edm2_model.to(accelerator.device)
+            edm2_model.train()
+            # Keep optimizer and scheduler as regular PyTorch objects
+        else:
+            edm2_lr_scheduler = accelerator.prepare(edm2_lr_scheduler)
+            edm2_model, edm2_optimizer = accelerator.prepare(edm2_model, edm2_optimizer)
     else:
         edm2_optimizer = None
         edm2_lr_scheduler = None
@@ -94,17 +104,20 @@ def plot_edm2_loss_weighting(args, step: int, model, num_timesteps: int = 1000, 
     """
     Plot the edm2 loss weighting across timesteps using the learned parameters.
 
-    :param model: The edm2 model instance (after training).
+    :param model: The edm2 model instance (after training). Can be DDP-wrapped.
     :param num_timesteps: Total number of timesteps to plot.
     :param device: Device to run computations on.
     """
+    # Unwrap DDP model if necessary
+    unwrapped_model = model.module if hasattr(model, 'module') else model
+
     with torch.inference_mode():
-        model.train(False)
+        unwrapped_model.train(False)
         timesteps = torch.arange(0, 1000, device=device, dtype=torch.long)
-        learnedweights = model._forward(timesteps).cpu().numpy()
-        lambdas = model.lambda_weights.cpu().numpy()
+        learnedweights = unwrapped_model._forward(timesteps).cpu().numpy()
+        lambdas = unwrapped_model.lambda_weights.cpu().numpy()
         learnedweights = lambdas/np.exp(learnedweights)
-        model.train(True)
+        unwrapped_model.train(True)
 
         # Plot the dynamic loss weights over time
         plt.figure(figsize=(10, 6))

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -1231,10 +1231,20 @@ def train(args):
                 edm2_loss = loss
                 loss = pre_scaling_loss
 
+                # Sync EDM2 gradients explicitly across GPUs (for DDP and DeepSpeed compatibility)
+                # Must happen before any gradient clipping
+                if args.edm2_loss_weighting and accelerator.sync_gradients:
+                    for param in edm2_model.parameters():
+                        if param.grad is not None:
+                            param.grad = accelerator.reduce(param.grad, reduction="mean")
+
                 if not (args.fused_backward_pass or args.fused_optimizer_groups):
                     if accelerator.sync_gradients and args.max_grad_norm != 0.0:
                         params_to_clip = []
                         for m in training_models:
+                            # Skip EDM2 model - it has its own gradient clipping with potentially different norm
+                            if args.edm2_loss_weighting and m is edm2_model:
+                                continue
                             params_to_clip.extend(m.parameters())
                         accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
@@ -1249,6 +1259,14 @@ def train(args):
                             lr_schedulers[i].step()
 
                 if args.edm2_loss_weighting:
+                    # Apply gradient clipping for EDM2 (with separate grad norm if specified)
+                    if accelerator.sync_gradients:
+                        edm2_grad_norm = (args.edm2_loss_weighting_max_grad_norm
+                                         if args.edm2_loss_weighting_max_grad_norm is not None
+                                         else args.max_grad_norm)
+                        if edm2_grad_norm != 0.0:
+                            edm2_params = list(accelerator.unwrap_model(edm2_model).parameters())
+                            accelerator.clip_grad_norm_(edm2_params, edm2_grad_norm)
                     edm2_optimizer.step()
                     edm2_lr_scheduler.step()
                     edm2_optimizer.zero_grad(set_to_none=True)
@@ -1745,6 +1763,13 @@ def setup_parser() -> argparse.ArgumentParser:
         "--edm2_loss_weighting_importance_weighting_safety_override",
         action="store_true",
         help="At your own risk, you may set this to true to ALLOW stacking debiased loss and/or typical min snr gamma with EDM2 using importance weighting.",
+    )
+
+    parser.add_argument(
+        "--edm2_loss_weighting_max_grad_norm",
+        type=float,
+        default=None,
+        help="Maximum gradient norm for EDM2 loss weighting model. If not specified, uses --max_grad_norm value. Set to 0 to disable clipping for EDM2. / EDM2損失重み付けモデルの最大勾配ノルム。指定しない場合は--max_grad_normの値を使用。0に設定するとEDM2のクリッピングを無効化。"
     )
 
     parser.add_argument(

--- a/train_network.py
+++ b/train_network.py
@@ -265,6 +265,14 @@ class NetworkTrainer:
             if param.grad is not None:
                 param.grad = accelerator.reduce(param.grad, reduction="mean")
 
+    def all_reduce_edm2_model(self, accelerator, edm2_model):
+        """Manually synchronize EDM2 model gradients across GPUs."""
+        if edm2_model is None:
+            return
+        for param in edm2_model.parameters():
+            if param.grad is not None:
+                param.grad = accelerator.reduce(param.grad, reduction="mean")
+
     def sample_images(self, accelerator, args, epoch, global_step, device, vae, tokenizers, text_encoder, unet):
         train_util.sample_images(accelerator, args, epoch, global_step, device, vae, tokenizers[0], text_encoder, unet)
 
@@ -1915,6 +1923,17 @@ class NetworkTrainer:
                             params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
                             accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
+                        # Sync and clip EDM2 gradients
+                        if args.edm2_loss_weighting:
+                            self.all_reduce_edm2_model(accelerator, edm2_model)
+                            # Use edm2-specific grad norm if provided, otherwise use max_grad_norm
+                            edm2_grad_norm = (args.edm2_loss_weighting_max_grad_norm
+                                             if args.edm2_loss_weighting_max_grad_norm is not None
+                                             else args.max_grad_norm)
+                            if edm2_grad_norm != 0.0:
+                                edm2_params = list(accelerator.unwrap_model(edm2_model).parameters())
+                                accelerator.clip_grad_norm_(edm2_params, edm2_grad_norm)
+
                         #if hasattr(network, "update_grad_norms"):
                         #    network.update_grad_norms()
                         #if hasattr(network, "update_norms"):
@@ -2022,8 +2041,6 @@ class NetworkTrainer:
                                             remove_loss_weights_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no, "_edm2_loss_weights")
                                             remove_model(remove_loss_weights_ckpt_name)
 
-                            if plot_edm2_loss_weighting_check(args, global_step):
-                                plot_edm2_loss_weighting(args, global_step, edm2_model, 1000, accelerator.device)
                             optimizer_train_fn()
                             accelerator.unwrap_model(network).train()
                             if args.gradient_checkpointing:
@@ -2032,6 +2049,10 @@ class NetworkTrainer:
                                     accelerator.unwrap_model(t_enc).train()
                     else:
                         current_val_loss, average_val_loss, val_logs = None, None, None
+
+                    # EDM2 graph generation - moved outside the sample/val/save conditional
+                    if plot_edm2_loss_weighting_check(args, global_step):
+                        plot_edm2_loss_weighting(args, global_step, edm2_model, 1000, accelerator.device)
 
                 current_global_step_loss += loss.detach().item()
                 if args.edm2_loss_weighting:
@@ -2498,6 +2519,13 @@ def setup_parser() -> argparse.ArgumentParser:
         "--edm2_loss_weighting_importance_weighting_safety_override",
         action="store_true",
         help="At your own risk, you may set this to true to ALLOW stacking debiased loss and/or typical min snr gamma with EDM2 using importance weighting.",
+    )
+
+    parser.add_argument(
+        "--edm2_loss_weighting_max_grad_norm",
+        type=float,
+        default=None,
+        help="Maximum gradient norm for EDM2 loss weighting model. If not specified, uses --max_grad_norm value. Set to 0 to disable clipping for EDM2. / EDM2損失重み付けモデルの最大勾配ノルム。指定しない場合は--max_grad_normの値を使用。0に設定するとEDM2のクリッピングを無効化。"
     )
 
     parser.add_argument(


### PR DESCRIPTION
What the painful tittle says, allows EDM2 for multi-gpu in DDP mode for Lycoris, and for sdxl_train.py extra handling for DDP vs DeepSpeed and --fused_optimizer_group, added --edm2_loss_weighting_max_grad_norm, which takes an integer, allows usage of max_grad_norm in case we *might* need it for FFT or big LoKRs, defaults to none and has a fallback to max_grad_norm set in base config, a good default seems to be 5, as some grads in EDM2 are in the range of 1.4 to 2.6 in SDXL flow.