### PR TITLE
Feat: Add Chroma Radiance support

### DIFF
--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -53,12 +53,12 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         super().assert_extra_args(args, train_dataset_group, val_dataset_group)
         # sdxl_train_util.verify_sdxl_training_args(args)
 
-        self.model_type = args.model_type  # "flux" or "chroma"
-        if self.model_type != "chroma":
+        self.model_type = args.model_type  # "flux", "chroma", or "chroma_radiance"
+        if self.model_type not in ("chroma", "chroma_radiance"):
             self.use_clip_l = True
         else:
-            self.use_clip_l = False  # Chroma does not use CLIP-L
-            assert args.apply_t5_attn_mask, "apply_t5_attn_mask must be True for Chroma / Chromaではapply_t5_attn_maskを指定する必要があります"
+            self.use_clip_l = False  # Chroma / ChromaRadiance do not use CLIP-L
+            assert args.apply_t5_attn_mask, "apply_t5_attn_mask must be True for Chroma / ChromaRadiance / Chromaではapply_t5_attn_maskを指定する必要があります"
 
         if args.fp8_base_unet:
             args.fp8_base = True  # if fp8_base_unet is enabled, fp8_base is also enabled for FLUX.1
@@ -109,7 +109,11 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         # currently offload to cpu for some models
 
         # if the file is fp8 and we are using fp8_base, we can load it as is (fp8)
-        loading_dtype = None if args.fp8_base else weight_dtype
+        # keep_unet_dtype: always load in native dtype
+        if args.keep_unet_dtype:
+            loading_dtype = None
+        else:
+            loading_dtype = None if args.fp8_base else weight_dtype
 
         # if we load to cpu, flux.to(fp8) takes a long time, so we should load to gpu in future
         _, model = flux_utils.load_flow_model(
@@ -119,7 +123,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
             disable_mmap=args.disable_mmap_load_safetensors,
             model_type=self.model_type,
         )
-        if args.fp8_base:
+        if args.fp8_base and not args.keep_unet_dtype:
             # check dtype of model
             if model.dtype == torch.float8_e4m3fnuz or model.dtype == torch.float8_e5m2 or model.dtype == torch.float8_e5m2fnuz:
                 raise ValueError(f"Unsupported fp8 model dtype: {model.dtype}")
@@ -131,6 +135,12 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
                     " / FLUXモデルをfp8に変換しています。これには時間がかかる場合があります。fp8チェックポイントを使用することで時間を短縮できます。"
                 )
                 model.to(torch.float8_e4m3fn)
+        elif args.keep_unet_dtype:
+            logger.info(f"Keeping FLUX model in its loaded dtype: {model.dtype}")
+
+        if self.model_type == "chroma_radiance" and hasattr(args, "nerf_tile_size") and args.nerf_tile_size > 0:
+            model.params.nerf_tile_size = args.nerf_tile_size
+            logger.info(f"NeRF head tiling enabled with tile_size={args.nerf_tile_size}")
 
         # if args.split_mode:
         #     model = self.prepare_split_model(model, weight_dtype, accelerator)
@@ -148,7 +158,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         if self.use_clip_l:
             clip_l = flux_utils.load_clip_l(args.clip_l, weight_dtype, "cpu", disable_mmap=args.disable_mmap_load_safetensors)
         else:
-            clip_l = flux_utils.dummy_clip_l()  # dummy CLIP-L for Chroma, which does not use CLIP-L
+            clip_l = flux_utils.dummy_clip_l()  # dummy CLIP-L for Chroma / ChromaRadiance, which does not use CLIP-L
         clip_l.eval()
 
         # if the file is fp8 and we are using fp8_base (not unet), we can load it as is (fp8)
@@ -163,23 +173,32 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         if args.fp8_base and not args.fp8_base_unet:
             # check dtype of model
             if t5xxl.dtype == torch.float8_e4m3fnuz or t5xxl.dtype == torch.float8_e5m2 or t5xxl.dtype == torch.float8_e5m2fnuz:
-                raise ValueError(f"Unsupported fp8 model dtype: {t5xxl.dtype}")
+                raise ValueError(f"Unsupported fp8 t5xxl dtype: {t5xxl.dtype}")
             elif t5xxl.dtype == torch.float8_e4m3fn:
                 logger.info("Loaded fp8 T5XXL model")
 
-        ae = flux_utils.load_ae(args.ae, weight_dtype, "cpu", disable_mmap=args.disable_mmap_load_safetensors)
+        if self.model_type == "chroma_radiance":
+            # Pixel-space model doesn't need a real VAE
+            ae = flux_utils._DummyVAE(weight_dtype, "cpu")
+        else:
+            ae = flux_utils.load_ae(args.ae, weight_dtype, "cpu", disable_mmap=args.disable_mmap_load_safetensors)
 
         if args.use_ramtorch and not args.cache_text_encoder_outputs:
             clip_l = apply_ramtorch_to_module(clip_l, "clip_l", accelerator.device, weight_dtype)
             t5xxl = apply_ramtorch_to_module(t5xxl, "t5xxl", accelerator.device, t5xxl.dtype)
 
-        model_version = flux_utils.MODEL_VERSION_FLUX_V1 if self.model_type != "chroma" else flux_utils.MODEL_VERSION_CHROMA
+        if self.model_type == "chroma_radiance":
+            model_version = flux_utils.MODEL_VERSION_CHROMA_RADIANCE
+        elif self.model_type == "chroma":
+            model_version = flux_utils.MODEL_VERSION_CHROMA
+        else:
+            model_version = flux_utils.MODEL_VERSION_FLUX_V1
         return model_version, [clip_l, t5xxl], ae, model
 
     def get_tokenize_strategy(self, args):
         # This method is called before `assert_extra_args`, so we cannot use `self.is_schnell` here.
         # Instead, we analyze the checkpoint state to determine if it is schnell.
-        if args.model_type != "chroma":
+        if args.model_type not in ("chroma", "chroma_radiance"):
             _, is_schnell, _, _ = flux_utils.analyze_checkpoint_state(args.pretrained_model_name_or_path)
         else:
             is_schnell = False
@@ -200,6 +219,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         return [tokenize_strategy.clip_l, tokenize_strategy.t5xxl]
 
     def get_latents_caching_strategy(self, args):
+        if self.model_type == "chroma_radiance":
+            return None  # pixel-space model, no latent caching needed
         latents_caching_strategy = strategy_flux.FluxLatentsCachingStrategy(args.cache_latents_to_disk, args.vae_batch_size, False)
         return latents_caching_strategy
 
@@ -312,7 +333,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         text_encoders = self.get_models_for_text_encoding(args, accelerator, text_encoders)
 
         flux_train_utils.sample_images(
-            accelerator, args, epoch, global_step, flux, ae, text_encoders, self.sample_prompts_te_outputs
+            accelerator, args, epoch, global_step, flux, ae, text_encoders, self.sample_prompts_te_outputs,
+            is_chroma_radiance=(self.model_type == "chroma_radiance"),
         )
 
     def get_noise_scheduler(self, args: argparse.Namespace, device: torch.device) -> Any:
@@ -321,6 +343,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         return noise_scheduler
 
     def encode_images_to_latents(self, args, vae, images):
+        if self.model_type == "chroma_radiance":
+            return images  # pixel-space model, no VAE encoding needed
         return vae.encode(images)
 
     def shift_scale_latents(self, args, latents):
@@ -355,6 +379,31 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         if is_train and getattr(self, "wavelet_masking_enabled", False):
             self._noisy_latents = noisy_model_input.detach()
 
+        # --- ChromaRadiance: pixel-space forward (no pack/unpack) ---
+        if self.model_type == "chroma_radiance":
+            l_pooled, t5_out, txt_ids, t5_attn_mask = text_encoder_conds
+            if not args.apply_t5_attn_mask:
+                t5_attn_mask = None
+
+            self.apply_tlora_mask(timesteps)
+
+            with torch.set_grad_enabled(is_train), accelerator.autocast():
+                model_pred = unet(
+                    x=noisy_model_input,
+                    t=timesteps / 1000,
+                    txt=t5_out,
+                    txt_mask=t5_attn_mask,
+                )
+
+            self.clear_tlora_mask_if_needed()
+
+            model_pred, weighting = flux_train_utils.apply_model_prediction_type(args, model_pred, noisy_model_input, sigmas)
+
+            target = noise - latents
+
+            return model_pred, target, timesteps, weighting, noise
+
+        # --- Standard Flux/Chroma latent-space path ---
         # pack latents and get img_ids
         packed_noisy_model_input = flux_utils.pack_latents(noisy_model_input)  # b, c, h*2, w*2 -> b, h*w, c*4
         packed_latent_height, packed_latent_width = noisy_model_input.shape[2] // 2, noisy_model_input.shape[3] // 2
@@ -577,7 +626,9 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         return loss
 
     def get_sai_model_spec(self, args):
-        if self.model_type != "chroma":
+        if self.model_type == "chroma_radiance":
+            model_description = "chroma_radiance"
+        elif self.model_type != "chroma":
             model_description = "schnell" if self.is_schnell else "dev"
         else:
             model_description = "chroma"
@@ -672,6 +723,13 @@ def setup_parser() -> argparse.ArgumentParser:
         # + "/[実験的] Fluxモデルの分割モードを使用する。ネットワーク引数`train_blocks=single`が必要",
         help="[Deprecated] This option is deprecated. Please use `--blocks_to_swap` instead."
         " / このオプションは非推奨です。代わりに`--blocks_to_swap`を使用してください。",
+    )
+    parser.add_argument(
+        "--nerf_tile_size",
+        type=int,
+        default=0,
+        help="tile size for NeRF head processing in Chroma Radiance (0=disabled, 128=process 128 patches at a time) "
+        "/ Chroma RadianceのNeRFヘッドのタイルサイズ（0=無効、128=128パッチずつ処理）",
     )
     return parser
 

--- a/library/chroma_radiance_models.py
+++ b/library/chroma_radiance_models.py
@@ -1,0 +1,472 @@
+# Chroma Radiance: pixel-space variant of Chroma with NeRF decoder head.
+# Reuses Chroma's backbone (DoubleStreamBlock, SingleStreamBlock, Approximator)
+# and adds Conv2d patchify + NeRF decoder for pixel-space operation.
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.utils.checkpoint as ckpt
+
+from torch import Tensor
+
+from .chroma_models import (
+    Chroma,
+    Approximator,
+    ModulationOut,
+    distribute_modulations,
+    modify_mask_to_attend_padding,
+    _modulation_shift_scale_fn,
+    _modulation_gate_fn,
+)
+from .flux_models import (
+    EmbedND,
+    RMSNorm,
+    timestep_embedding,
+)
+
+
+PATCH_SIZE = 16
+
+
+# ---------------------------------------------------------------------------
+# NeRF decoder components
+# ---------------------------------------------------------------------------
+
+
+class NerfEmbedder(nn.Module):
+    """DCT-like positional encoding + MLP for NeRF pixel embeddings."""
+
+    def __init__(self, in_channels: int, hidden_size_input: int, max_freqs: int, dtype: torch.dtype | None = None):
+        super().__init__()
+        self.max_freqs = max_freqs
+        self.embedder = nn.Sequential(
+            nn.Linear(in_channels + max_freqs**2, hidden_size_input)
+        )
+        self.nerf_embedder_dtype = dtype
+
+    @lru_cache(maxsize=4)
+    def fetch_pos(self, patch_size: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+        pos_x = torch.linspace(0, 1, patch_size, device=device, dtype=dtype)
+        pos_y = torch.linspace(0, 1, patch_size, device=device, dtype=dtype)
+        pos_y, pos_x = torch.meshgrid(pos_y, pos_x, indexing="ij")
+
+        pos_x = pos_x.reshape(-1, 1, 1)
+        pos_y = pos_y.reshape(-1, 1, 1)
+
+        freqs = torch.linspace(0, self.max_freqs - 1, self.max_freqs, dtype=dtype, device=device)
+        freqs_x = freqs[None, :, None]
+        freqs_y = freqs[None, None, :]
+
+        coeffs = (1 + freqs_x * freqs_y) ** -1
+        dct_x = torch.cos(pos_x * freqs_x * torch.pi)
+        dct_y = torch.cos(pos_y * freqs_y * torch.pi)
+        dct = (dct_x * dct_y * coeffs).view(1, -1, self.max_freqs**2)
+        return dct
+
+    def forward(self, inputs: Tensor) -> Tensor:
+        input_dtype = inputs.dtype
+        if self.nerf_embedder_dtype is not None:
+            inputs = inputs.to(self.nerf_embedder_dtype)
+        with torch.autocast("cuda", enabled=False):
+            patch_size = int(inputs.shape[1]**0.5)
+            inputs = inputs.float()
+            dct = self.fetch_pos(patch_size, inputs.device, torch.float32)
+            dct = dct.repeat(inputs.shape[0], 1, 1)
+            inputs = torch.cat([inputs, dct], dim=-1)
+            inputs = self.embedder.float()(inputs)
+        return inputs.to(input_dtype)
+
+
+class NerfGLUBlock(nn.Module):
+    """Hypernetwork GLU block: generates per-pixel MLP weights from backbone conditioning."""
+
+    def __init__(self, hidden_size_s: int, hidden_size_x: int, mlp_ratio: int, use_compiled: bool = False):
+        super().__init__()
+        total_params = 3 * hidden_size_x**2 * mlp_ratio
+        self.param_generator = nn.Linear(hidden_size_s, total_params)
+        self.norm = RMSNorm(hidden_size_x)
+        self.mlp_ratio = mlp_ratio
+
+    def forward(self, x: Tensor, s: Tensor) -> Tensor:
+        batch_size, num_x, hidden_size_x = x.shape
+        mlp_params = self.param_generator(s)
+
+        fc1_gate_params, fc1_value_params, fc2_params = mlp_params.chunk(3, dim=-1)
+
+        fc1_gate = fc1_gate_params.view(batch_size, hidden_size_x, hidden_size_x * self.mlp_ratio)
+        fc1_value = fc1_value_params.view(batch_size, hidden_size_x, hidden_size_x * self.mlp_ratio)
+        fc2 = fc2_params.view(batch_size, hidden_size_x * self.mlp_ratio, hidden_size_x)
+
+        fc1_gate = F.normalize(fc1_gate, dim=-2)
+        fc1_value = F.normalize(fc1_value, dim=-2)
+        fc2 = F.normalize(fc2, dim=-2)
+
+        res_x = x
+        x = self.norm(x)
+        x = torch.bmm(F.silu(torch.bmm(x, fc1_gate)) * torch.bmm(x, fc1_value), fc2)
+        x = x + res_x
+        return x
+
+
+class NerfFinalLayerConv(nn.Module):
+    """RMSNorm + 3x3 Conv2d output projection for NeRF decoder."""
+
+    def __init__(self, hidden_size: int, out_channels: int, use_compiled: bool = False):
+        super().__init__()
+        self.norm = RMSNorm(hidden_size)
+        self.conv = nn.Conv2d(
+            in_channels=hidden_size,
+            out_channels=out_channels,
+            kernel_size=3,
+            padding=1,
+        )
+        nn.init.zeros_(self.conv.weight)
+        nn.init.zeros_(self.conv.bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        # x: [B, C, H, W]
+        x_permuted = x.permute(0, 2, 3, 1)
+        x_norm = self.norm(x_permuted)
+        x_norm_permuted = x_norm.permute(0, 3, 1, 2)
+        x = self.conv(x_norm_permuted)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Position ID helpers (for patch_size=16)
+# ---------------------------------------------------------------------------
+
+
+def prepare_latent_image_ids(batch_size: int, height: int, width: int, patch_size: int = PATCH_SIZE) -> Tensor:
+    h_p = height // patch_size
+    w_p = width // patch_size
+    ids = torch.zeros(h_p, w_p, 3)
+    ids[..., 1] = torch.arange(h_p)[:, None]
+    ids[..., 2] = torch.arange(w_p)[None, :]
+    ids = ids.reshape(1, h_p * w_p, 3).expand(batch_size, -1, -1)
+    return ids.contiguous()
+
+
+def make_text_position_ids(batch_size: int, seq_len: int) -> Tensor:
+    ids = torch.zeros(seq_len, 3)
+    ids[:, 0] = torch.arange(seq_len)
+    return ids.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Params
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ChromaRadianceParams:
+    # Image / text
+    in_channels: int = 3
+    context_in_dim: int = 4096
+
+    # Backbone
+    hidden_size: int = 3072
+    mlp_ratio: float = 4.0
+    num_heads: int = 24
+    depth: int = 19
+    depth_single_blocks: int = 38
+    axes_dim: list[int] = field(default_factory=lambda: [16, 56, 56])
+    theta: int = 10_000
+    qkv_bias: bool = True
+
+    # Approximator (modulation distillation)
+    approximator_in_dim: int = 64
+    approximator_depth: int = 5
+    approximator_hidden_size: int = 5120
+
+    # NeRF decoder head
+    nerf_hidden_size: int = 64
+    nerf_mlp_ratio: int = 4
+    nerf_depth: int = 4
+    nerf_max_freqs: int = 8
+    nerf_tile_size: int = 0  # 0 = disabled (process all patches at once)
+    nerf_embedder_dtype: torch.dtype | None = None  # None = use model dtype
+
+    patch_size: int = PATCH_SIZE
+    _use_compiled: bool = False
+
+
+chroma_radiance_params = ChromaRadianceParams(
+    in_channels=3,
+    context_in_dim=4096,
+    hidden_size=3072,
+    mlp_ratio=4.0,
+    num_heads=24,
+    depth=19,
+    depth_single_blocks=38,
+    axes_dim=[16, 56, 56],
+    theta=10_000,
+    qkv_bias=True,
+    approximator_in_dim=64,
+    approximator_depth=5,
+    approximator_hidden_size=5120,
+    nerf_hidden_size=64,
+    nerf_mlp_ratio=4,
+    nerf_depth=4,
+    nerf_max_freqs=8,
+    nerf_tile_size=0,
+    patch_size=PATCH_SIZE,
+    _use_compiled=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Main model
+# ---------------------------------------------------------------------------
+
+
+class ChromaRadiance(Chroma):
+    """Pixel-space Chroma variant with NeRF decoder head.
+
+    Reuses Chroma's backbone (DoubleStreamBlock, SingleStreamBlock, Approximator)
+    and replaces img_in (Linear) with Conv2d patchify, final_layer (LastLayer)
+    with NeRF decoder.
+
+    forward(x, t, txt, txt_mask) -> predicted x0 in [B, 3, H, W].
+    """
+
+    def __init__(self, params: ChromaRadianceParams):
+        # Build Chroma with in_channels=3 (pixel space)
+        # This creates img_in as Linear(3, hidden_size) which we'll replace
+        super().__init__(params)
+        self.nerf_params = params
+        self.patch_size = params.patch_size
+
+        # Replace img_in (Linear) with Conv2d patchify
+        self.img_in_patch = nn.Conv2d(
+            params.in_channels,
+            params.hidden_size,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            bias=True,
+        )
+        nn.init.zeros_(self.img_in_patch.weight)
+        nn.init.zeros_(self.img_in_patch.bias)
+
+        # Remove the Linear img_in (not used)
+        del self.img_in
+
+        # Replace final_layer with NeRF decoder
+        del self.final_layer
+
+        self.nerf_image_embedder = NerfEmbedder(
+            in_channels=params.in_channels,
+            hidden_size_input=params.nerf_hidden_size,
+            max_freqs=params.nerf_max_freqs,
+            dtype=params.nerf_embedder_dtype,
+        )
+        self.nerf_blocks = nn.ModuleList([
+            NerfGLUBlock(
+                hidden_size_s=params.hidden_size,
+                hidden_size_x=params.nerf_hidden_size,
+                mlp_ratio=params.nerf_mlp_ratio,
+                use_compiled=params._use_compiled,
+            )
+            for _ in range(params.nerf_depth)
+        ])
+        self.nerf_final_layer_conv = NerfFinalLayerConv(
+            params.nerf_hidden_size,
+            out_channels=params.in_channels,
+            use_compiled=params._use_compiled,
+        )
+
+    def get_model_type(self) -> str:
+        return "chroma_radiance"
+
+    def enable_gradient_checkpointing(self, cpu_offload: bool = False):
+        self.gradient_checkpointing = True
+        self.cpu_offload_checkpointing = cpu_offload
+
+        self.distilled_guidance_layer.enable_gradient_checkpointing()
+        for block in self.double_blocks + self.single_blocks:
+            block.enable_gradient_checkpointing()
+
+        print(f"ChromaRadiance: Gradient checkpointing enabled.")
+
+    def disable_gradient_checkpointing(self):
+        self.gradient_checkpointing = False
+        self.cpu_offload_checkpointing = False
+
+        self.distilled_guidance_layer.disable_gradient_checkpointing()
+        for block in self.double_blocks + self.single_blocks:
+            block.disable_gradient_checkpointing()
+
+        print("ChromaRadiance: Gradient checkpointing disabled.")
+
+    def _forward(
+        self,
+        img: Tensor,       # [B, C, H, W]  noisy image
+        img_ids: Tensor,   # [B, N, 3]
+        txt: Tensor,       # [B, L, context_in_dim]
+        txt_ids: Tensor,   # [B, L, 3]
+        txt_mask: Tensor,  # [B, L]  bool
+        timesteps: Tensor, # [B]  in [0, 1]
+    ) -> Tensor:
+        """Returns predicted x0 [B, C, H, W]."""
+        if img.ndim != 4:
+            raise ValueError("img must be [B, C, H, W]")
+        B, C, H, W = img.shape
+
+        # Extract raw patch pixels for NeRF decoder
+        nerf_pixels = F.unfold(img, kernel_size=self.patch_size, stride=self.patch_size)
+        nerf_pixels = nerf_pixels.transpose(1, 2)  # [B, N, C*P*P]
+        num_patches = nerf_pixels.shape[1]
+
+        # Patchify image for transformer backbone
+        img_hidden = self.img_in_patch(img)  # [B, hidden, H/P, W/P]
+        img_hidden = img_hidden.flatten(2).transpose(1, 2)  # [B, N, hidden]
+
+        # Text projection
+        txt_hidden = self.txt_in(txt)  # [B, L, hidden]
+
+        # Compute txt_seq_len per element (Chroma's per-element attention approach)
+        txt_emb_len = txt_hidden.shape[1]
+        attn_padding = 1
+        txt_seq_len = txt_mask[:, :txt_emb_len].sum(dim=-1).to(torch.int64)
+        txt_seq_len = torch.clip(txt_seq_len + attn_padding, 0, txt_emb_len)
+
+        # Trim txt embedding to max text length
+        max_txt_len = torch.max(txt_seq_len).item()
+        txt_hidden = txt_hidden[:, :max_txt_len, :]
+
+        # Distill all modulation vectors (Approximator in no_grad)
+        guidance_val = torch.zeros(B, device=img.device, dtype=timesteps.dtype)
+        approx_dtype = next(self.distilled_guidance_layer.parameters()).dtype
+        with torch.no_grad():
+            self.mod_index = self.mod_index.to(img.device)
+            distill_timestep = timestep_embedding(timesteps, self.approximator_in_dim // 4)
+            distil_guidance = timestep_embedding(guidance_val, self.approximator_in_dim // 4)
+            modulation_index = timestep_embedding(self.mod_index, self.approximator_in_dim // 2)
+            modulation_index = modulation_index.unsqueeze(0).expand(B, -1, -1)
+            timestep_guidance = (
+                torch.cat([distill_timestep, distil_guidance], dim=1)
+                .unsqueeze(1)
+                .expand(-1, self.mod_index_length, -1)
+            )
+            input_vec = torch.cat([timestep_guidance, modulation_index], dim=-1).to(approx_dtype)
+            mod_vectors = self.distilled_guidance_layer(input_vec.requires_grad_(True))
+
+        mod_vectors_dict = distribute_modulations(
+            mod_vectors, self.depth_single_blocks, self.depth_double_blocks
+        )
+
+        # RoPE position embeddings (img first, then txt — Chroma convention)
+        ids = torch.cat((img_ids, txt_ids[:, :max_txt_len]), dim=1)
+        pe = self.pe_embedder(ids)
+
+
+        # Double-stream blocks (Chroma handles checkpointing internally in each block)
+        for i, block in enumerate(self.double_blocks):
+            img_mod = mod_vectors_dict[f"double_blocks.{i}.img_mod.lin"]
+            txt_mod = mod_vectors_dict[f"double_blocks.{i}.txt_mod.lin"]
+            double_mod = [img_mod, txt_mod]
+            del img_mod, txt_mod
+
+            img_hidden, txt_hidden = block(
+                img=img_hidden, txt=txt_hidden,
+                pe=pe, distill_vec=double_mod, txt_seq_len=txt_seq_len,
+            )
+            del double_mod
+
+        # Merge streams for single-stream blocks
+        merged = torch.cat((img_hidden, txt_hidden), dim=1)
+        del txt_hidden
+
+        for i, block in enumerate(self.single_blocks):
+            single_mod = mod_vectors_dict[f"single_blocks.{i}.modulation.lin"]
+            merged = block(merged, pe=pe, distill_vec=single_mod, txt_seq_len=txt_seq_len)
+            del single_mod
+
+        # Strip text prefix — img_hidden is the first num_patches tokens
+        img_hidden = merged[:, :num_patches, :]
+        del merged
+
+        # NeRF decoder
+        nerf_cond = img_hidden.reshape(B * num_patches, self.params.hidden_size)
+        del img_hidden
+
+        nerf_pixels = nerf_pixels.reshape(B * num_patches, C, self.patch_size**2)
+        nerf_pixels = nerf_pixels.transpose(1, 2)
+
+        # Tiled or full NeRF processing
+        tile_size = self.params.nerf_tile_size
+        use_gc = self.gradient_checkpointing
+
+        def run_nerf_blocks(dct, cond):
+            for block in self.nerf_blocks:
+                if use_gc:
+                    dct = ckpt.checkpoint(block, dct, cond, use_reentrant=False)
+                else:
+                    dct = block(dct, cond)
+            return dct
+
+        if tile_size > 0 and num_patches > tile_size:
+            output_tiles = []
+            for i in range(0, num_patches, tile_size):
+                end = min(i + tile_size, num_patches)
+                hidden_tile = nerf_cond[i * B:end * B]
+                pixels_tile = nerf_pixels[i * B:end * B]
+                dct_tile = self.nerf_image_embedder(pixels_tile)
+                del pixels_tile
+                dct_tile = run_nerf_blocks(dct_tile, hidden_tile)
+                del hidden_tile
+                output_tiles.append(dct_tile)
+            del nerf_cond, nerf_pixels
+            img_dct = torch.cat(output_tiles, dim=0)
+            del output_tiles
+        else:
+            img_dct = self.nerf_image_embedder(nerf_pixels)
+            del nerf_pixels
+            img_dct = run_nerf_blocks(img_dct, nerf_cond)
+            del nerf_cond
+
+        # Reconstruct image via fold
+        img_dct = self.nerf_final_layer_conv.norm(img_dct)
+        img_dct = img_dct.transpose(1, 2)
+        img_dct = img_dct.reshape(B, num_patches, -1)
+        img_dct = img_dct.transpose(1, 2)
+        img_dct = F.fold(
+            img_dct,
+            output_size=(H, W),
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        output = self.nerf_final_layer_conv.conv(img_dct)
+        del img_dct
+
+        return output  # predicted x0
+
+    def forward(
+        self,
+        x: Tensor,         # [B, 3, H, W]  noisy image
+        t: Tensor,         # [B]  timestep in [0, 1]
+        txt: Tensor,       # [B, L, context_in_dim]
+        txt_mask: Tensor,  # [B, L]  bool
+    ) -> Tensor:
+        """Returns v-prediction [B, 3, H, W]."""
+        t = t.view(-1)
+        B, C, H, W = x.shape
+
+        img_ids = prepare_latent_image_ids(B, H, W, self.patch_size).to(x.device)
+        txt_ids = make_text_position_ids(B, txt.shape[1]).to(x.device)
+
+        predicted_x0 = self._forward(x, img_ids, txt, txt_ids, txt_mask, t)
+
+        # Convert x0 prediction to v-prediction: v = (noisy - x0) / (t + eps)
+        eps = 5e-2 if self.training else 0.0
+        return (x - predicted_x0) / (t.view(-1, 1, 1, 1) + eps)
+
+    def prepare_block_swap_before_forward(self):
+        """No-op for compatibility with training pipeline."""
+        pass

--- a/library/flux_train_utils.py
+++ b/library/flux_train_utils.py
@@ -43,6 +43,7 @@ def sample_images(
     sample_prompts_te_outputs,
     prompt_replacement=None,
     controlnet=None,
+    is_chroma_radiance=False,
 ):
     if steps == 0:
         if not args.sample_at_first:
@@ -89,9 +90,10 @@ def sample_images(
 
     if distributed_state.num_processes <= 1:
         # If only one device is available, just use the original prompt list. We don't need to care about the distribution of prompts.
+        sample_fn = sample_image_inference_chroma_radiance if is_chroma_radiance else sample_image_inference
         with torch.no_grad(), accelerator.autocast():
             for prompt_dict in prompts:
-                sample_image_inference(
+                sample_fn(
                     accelerator,
                     args,
                     flux,
@@ -113,9 +115,10 @@ def sample_images(
             per_process_prompts.append(prompts[i :: distributed_state.num_processes])
 
         with torch.no_grad():
+            sample_fn = sample_image_inference_chroma_radiance if is_chroma_radiance else sample_image_inference
             with distributed_state.split_between_processes(per_process_prompts) as prompt_dict_lists:
                 for prompt_dict in prompt_dict_lists[0]:
-                    sample_image_inference(
+                    sample_fn(
                         accelerator,
                         args,
                         flux,
@@ -308,6 +311,105 @@ def time_shift(mu: float, sigma: float, t: torch.Tensor):
     return math.exp(mu) / (math.exp(mu) + (1 / t - 1) ** sigma)
 
 
+def sample_image_inference_chroma_radiance(
+    accelerator: Accelerator,
+    args: argparse.Namespace,
+    flux,
+    text_encoders,
+    ae,  # unused, kept for signature compatibility
+    save_dir,
+    prompt_dict,
+    epoch,
+    steps,
+    sample_prompts_te_outputs,
+    prompt_replacement,
+    controlnet,  # unused
+):
+    """Sample image inference for pixel-space ChromaRadiance."""
+    assert isinstance(prompt_dict, dict)
+    sample_steps = prompt_dict.get("sample_steps", 20)
+    width = prompt_dict.get("width", 512)
+    height = prompt_dict.get("height", 512)
+    seed = prompt_dict.get("seed")
+    prompt: str = prompt_dict.get("prompt", "")
+
+    if prompt_replacement is not None:
+        prompt = prompt.replace(prompt_replacement[0], prompt_replacement[1])
+
+    if seed is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+    else:
+        torch.seed()
+        torch.cuda.seed()
+
+    height = max(64, height - height % 16)
+    width = max(64, width - width % 16)
+    logger.info(f"prompt: {prompt}")
+    logger.info(f"height: {height}, width: {width}")
+    logger.info(f"sample_steps: {sample_steps}")
+    if seed is not None:
+        logger.info(f"seed: {seed}")
+
+    # encode prompts
+    tokenize_strategy = strategy_base.TokenizeStrategy.get_strategy()
+    encoding_strategy = strategy_base.TextEncodingStrategy.get_strategy()
+
+    def encode_prompt(prpt):
+        text_encoder_conds = []
+        if sample_prompts_te_outputs and prpt in sample_prompts_te_outputs:
+            text_encoder_conds = sample_prompts_te_outputs[prpt]
+        if text_encoders is not None:
+            tokens_and_masks = tokenize_strategy.tokenize(prpt)
+            encoded = encoding_strategy.encode_tokens(tokenize_strategy, text_encoders, tokens_and_masks)
+            if len(text_encoder_conds) == 0:
+                text_encoder_conds = encoded
+            else:
+                for i in range(len(encoded)):
+                    if encoded[i] is not None:
+                        text_encoder_conds[i] = encoded[i]
+        return text_encoder_conds
+
+    l_pooled, t5_out, txt_ids, t5_attn_mask = encode_prompt(prompt)
+    t5_attn_mask = t5_attn_mask.to(accelerator.device) if args.apply_t5_attn_mask and t5_attn_mask is not None else None
+
+    # Create pixel-space noise
+    weight_dtype = t5_out.dtype
+    noise = torch.randn(
+        1, 3, height, width,
+        device=accelerator.device,
+        dtype=weight_dtype,
+        generator=torch.Generator(device=accelerator.device).manual_seed(seed) if seed is not None else None,
+    )
+    timesteps = get_schedule(sample_steps, noise.shape[2] // 16 * noise.shape[3] // 16, shift=True)
+
+    with accelerator.autocast(), torch.no_grad():
+        x = denoise_chroma_radiance(
+            flux,
+            noise,
+            t5_out,
+            timesteps=timesteps,
+            t5_attn_mask=t5_attn_mask,
+        )
+
+    # Save image (pixel-space output, no VAE decode needed)
+    x = x.clamp(-1, 1)
+    x = x.permute(0, 2, 3, 1)
+    image = Image.fromarray((127.5 * (x + 1.0)).float().cpu().numpy().astype(np.uint8)[0])
+
+    ts_str = time.strftime("%Y%m%d%H%M%S", time.localtime())
+    num_suffix = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
+    seed_suffix = "" if seed is None else f"_{seed}"
+    i: int = prompt_dict["enum"]
+    img_filename = f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{i:02d}_{ts_str}{seed_suffix}.png"
+    image.save(os.path.join(save_dir, img_filename))
+
+    if "wandb" in [tracker.name for tracker in accelerator.trackers]:
+        wandb_tracker = accelerator.get_tracker("wandb")
+        import wandb
+        wandb_tracker.log({f"sample_{i}": wandb.Image(image, caption=prompt)}, commit=False)
+
+
 def get_lin_function(x1: float = 256, y1: float = 0.5, x2: float = 4096, y2: float = 1.15) -> Callable[[float], float]:
     m = (y2 - y1) / (x2 - x1)
     b = y1 - m * x1
@@ -417,6 +519,31 @@ def denoise(
     return img
 
 
+def denoise_chroma_radiance(
+    model,
+    img: torch.Tensor,          # [1, 3, H, W] pixel-space noise
+    txt: torch.Tensor,          # t5_out
+    timesteps: list[float],
+    t5_attn_mask: Optional[torch.Tensor] = None,
+):
+    """Euler denoising loop for pixel-space ChromaRadiance."""
+    for t_curr, t_prev in zip(tqdm(timesteps[:-1]), timesteps[1:]):
+        t_vec = torch.full((img.shape[0],), t_curr, dtype=img.dtype, device=img.device)
+        model.prepare_block_swap_before_forward()
+
+        pred = model(
+            x=img,
+            t=t_vec,
+            txt=txt,
+            txt_mask=t5_attn_mask,
+        )
+
+        img = img + (t_prev - t_curr) * pred
+
+    model.prepare_block_swap_before_forward()
+    return img
+
+
 # endregion
 
 
@@ -508,6 +635,16 @@ def get_noisy_model_input_and_timesteps(
         sigmas = sigmas.sigmoid()
         mu = get_lin_function(y1=0.5, y2=1.15)((h // 2) * (w // 2))  # we are pre-packed so must adjust for packed size
         sigmas = time_shift(mu, 1.0, sigmas)
+        timesteps = sigmas * num_timesteps
+    elif args.timestep_sampling == "hump":
+        # Inverted parabola distribution centered at hump_center
+        num_points = num_timesteps
+        x = torch.linspace(0, 1, num_points, device=device)
+        probabilities = -7.7 * ((x - args.hump_center) ** 2) + 2
+        probabilities = probabilities.clamp(min=0)
+        probabilities /= probabilities.sum()
+        indices = torch.multinomial(probabilities.unsqueeze(0).expand(bsz, -1), 1).squeeze(-1)
+        sigmas = x[indices]
         timesteps = sigmas * num_timesteps
     else:
         # Sample a random timestep for each image
@@ -666,7 +803,7 @@ def add_flux_train_arguments(parser: argparse.ArgumentParser):
 
     parser.add_argument(
         "--timestep_sampling",
-        choices=["sigma", "uniform", "sigmoid", "shift", "flux_shift"],
+        choices=["sigma", "uniform", "sigmoid", "shift", "flux_shift", "hump"],
         default="sigma",
         help="Method to sample timesteps: sigma-based, uniform random, sigmoid of random normal, shift of sigmoid and FLUX.1 shifting."
         " / タイムステップをサンプリングする方法：sigma、random uniform、random normalのsigmoid、sigmoidのシフト、FLUX.1のシフト。",
@@ -676,6 +813,12 @@ def add_flux_train_arguments(parser: argparse.ArgumentParser):
         type=float,
         default=1.0,
         help='Scale factor for sigmoid timestep sampling (only used when timestep-sampling is "sigmoid"). / sigmoidタイムステップサンプリングの倍率（timestep-samplingが"sigmoid"の場合のみ有効）。',
+    )
+    parser.add_argument(
+        "--hump_center",
+        type=float,
+        default=0.5,
+        help='Center position for "hump" timestep sampling distribution (0.0-1.0). / "hump"タイムステップサンプリング分布の中心位置（0.0-1.0）。',
     )
     parser.add_argument(
         "--model_prediction_type",

--- a/library/flux_utils.py
+++ b/library/flux_utils.py
@@ -24,6 +24,7 @@ MODEL_VERSION_FLUX_V1 = "flux1"
 MODEL_NAME_DEV = "dev"
 MODEL_NAME_SCHNELL = "schnell"
 MODEL_VERSION_CHROMA = "chroma"
+MODEL_VERSION_CHROMA_RADIANCE = "chroma_radiance"
 
 
 def analyze_checkpoint_state(ckpt_path: str) -> Tuple[bool, bool, Tuple[int, int], List[str]]:
@@ -169,8 +170,36 @@ def load_flow_model(
         is_schnell = False  # Chroma is not schnell
         return is_schnell, model
 
+    elif model_type == "chroma_radiance":
+        from . import chroma_radiance_models
+
+        # build model
+        logger.info("Building ChromaRadiance model")
+        with torch.device("meta"):
+            model = chroma_radiance_models.ChromaRadiance(
+                chroma_radiance_models.chroma_radiance_params
+            )
+            if dtype is not None:
+                model = model.to(dtype)
+
+        # load_sft doesn't support torch.device
+        logger.info(f"Loading state dict from {ckpt_path}")
+        sd = load_safetensors(ckpt_path, device=str(device), disable_mmap=disable_mmap, dtype=dtype)
+
+        # if the key has annoying prefix, remove it
+        for key in list(sd.keys()):
+            new_key = key.replace("model.diffusion_model.", "")
+            if new_key == key:
+                break  # the model doesn't have annoying prefix
+            sd[new_key] = sd.pop(key)
+
+        info = model.load_state_dict(sd, strict=False, assign=True)
+        logger.info(f"Loaded ChromaRadiance: {info}")
+        is_schnell = False  # ChromaRadiance is not schnell
+        return is_schnell, model
+
     else:
-        raise ValueError(f"Unsupported model_type: {model_type}. Supported types are 'flux' and 'chroma'.")
+        raise ValueError(f"Unsupported model_type: {model_type}. Supported types are 'flux', 'chroma', and 'chroma_radiance'.")
 
 
 def load_ae(
@@ -242,6 +271,28 @@ class DummyCLIPL(torch.nn.Module):
         """
         batch_size = args[0].shape[0] if args else 1
         return {"pooler_output": torch.zeros(batch_size, *self.output_shape, device=self.device, dtype=self.dtype)}
+
+
+class _DummyVAE(torch.nn.Module):
+    """Stub VAE for pixel-space models that don't need encoding."""
+
+    def __init__(self, dtype: torch.dtype, device: torch.device):
+        super().__init__()
+        self.dummy_param = torch.nn.Parameter(torch.zeros(1), requires_grad=False)
+
+    @property
+    def device(self):
+        return self.dummy_param.device
+
+    @property
+    def dtype(self):
+        return self.dummy_param.dtype
+
+    def encode(self, x):
+        return x
+
+    def decode(self, x):
+        return x
 
 
 def load_clip_l(

--- a/library/lumina_train_util.py
+++ b/library/lumina_train_util.py
@@ -864,6 +864,16 @@ def get_noisy_model_input_and_timesteps(
         mu = get_lin_function(y1=0.5, y2=1.15)((h // 2) * (w // 2))  # we are pre-packed so must adjust for packed size
         sigmas = time_shift(mu, 1.0, sigmas)
         timesteps = sigmas * num_timesteps
+    elif args.timestep_sampling == "hump":
+        # Inverted parabola distribution centered at hump_center
+        num_points = num_timesteps
+        x = torch.linspace(0, 1, num_points, device=device)
+        probabilities = -7.7 * ((x - args.hump_center) ** 2) + 2
+        probabilities = probabilities.clamp(min=0)
+        probabilities /= probabilities.sum()
+        indices = torch.multinomial(probabilities.unsqueeze(0).expand(bsz, -1), 1).squeeze(-1)
+        sigmas = x[indices]
+        timesteps = sigmas * num_timesteps
     else:
         # Sample a random timestep for each image
         # for weighting schemes where we sample timesteps non-uniformly
@@ -1066,7 +1076,7 @@ def add_lumina_train_arguments(parser: argparse.ArgumentParser):
 
     parser.add_argument(
         "--timestep_sampling",
-        choices=["sigma", "uniform", "sigmoid", "shift", "nextdit_shift", "flux_shift"],
+        choices=["sigma", "uniform", "sigmoid", "shift", "nextdit_shift", "flux_shift", "hump"],
         default="shift",
         help="Method to sample timesteps: sigma-based, uniform random, sigmoid of random normal, shift of sigmoid, Flux.1 and NextDIT.1 shifting. Default is 'shift'."
         " / タイムステップをサンプリングする方法：sigma、random uniform、random normalのsigmoid、sigmoidのシフト、Flux.1、NextDIT.1のシフト。デフォルトは'shift'です。",
@@ -1076,6 +1086,12 @@ def add_lumina_train_arguments(parser: argparse.ArgumentParser):
         type=float,
         default=1.0,
         help='Scale factor for sigmoid timestep sampling (only used when timestep-sampling is "sigmoid"). / sigmoidタイムステップサンプリングの倍率（timestep-samplingが"sigmoid"の場合のみ有効）。',
+    )
+    parser.add_argument(
+        "--hump_center",
+        type=float,
+        default=0.5,
+        help='Center position for "hump" timestep sampling distribution (0.0-1.0). / "hump"タイムステップサンプリング分布の中心位置（0.0-1.0）。',
     )
     parser.add_argument(
         "--model_prediction_type",

--- a/train_network.py
+++ b/train_network.py
@@ -1698,10 +1698,13 @@ class NetworkTrainer:
             # logger.info(f"set U-Net weight dtype to {unet_weight_dtype}, device to {accelerator.device}")
             # unet.to(accelerator.device, dtype=unet_weight_dtype)  # this seems to be safer than above
             logger.info(f"set U-Net weight dtype to {unet_weight_dtype}")
-            unet.to(dtype=unet_weight_dtype)  # do not move to device because unet is not prepared by accelerator
+            if not args.keep_unet_dtype:
+                unet.to(dtype=unet_weight_dtype)  # do not move to device because unet is not prepared by accelerator
+            else:
+                accelerator.print(f"keeping U-Net in its loaded dtype (skip fp8 cast)")
 
         unet.requires_grad_(False)
-        if self.cast_unet(args):
+        if self.cast_unet(args) and not args.keep_unet_dtype:
             unet.to(dtype=unet_weight_dtype)
         for i, t_enc in enumerate(text_encoders):
             t_enc.requires_grad_(False)


### PR DESCRIPTION
Implements Chroma Radiance & a few other enhancements for the Chroma model series.

* Adds support for Chroma Radiance (via `model_type = chroma_radiance`)
* Adds the `hump` method for `timestep_sampling`, similar to sigmoid/logit-normal but the tails are slightly heavier (more likely), ensuring that the first and last timesteps get sampled from more often relative to sigmoid/logit-normal, where they'd originally almost never get sampled.
* Adds `nerf_tile_size` for memory efficiency if needed (Tiles the NeRF head, trading throughput for memory efficiency)
* Adds `nerf_embedder_dtype` for memory efficiency (Recommended to set to `torch.bfloat16` or a similar 16-bit precision datatype for memory efficiency)
* Adds `keep_model_dtype` which keeps the selected UNet/diffusion model in its storage dtype during training, allowing the usage of mixed-precision models without casting them to a higher or lower precision. Useful for keeping some layers in a necessary higher-precision (i.e. distilled_guidance_layers, nerf-related layers, others...)